### PR TITLE
更改该文档第六十行的翻译内容

### DIFF
--- a/src/pages/docs/features/protected-folders.zh.mdx
+++ b/src/pages/docs/features/protected-folders.zh.mdx
@@ -57,7 +57,7 @@ import Video from '../../../components/video'
 "protectedRoutes": [],
 ```
 
-你也许在想要不要加密填写在 `.password` 文件里的访问密码，不需要。该文件内的内容就是你访问该文件夹时需要的密码。
+在上述添加的私密文件夹内创建一个 `.password` 文件，该文件内的纯文本内容就是你访问该文件夹时需要的密码。
 
 ![What to write inside .password](../_images/features/dot-password-file.png)
 


### PR DESCRIPTION
英文原文：

> If you are confused about whether you need to encrypt your password, don't. Put that plain text inside .password. Whatever you save inside .password, you are going to use as the password for entering the protected directory.

修正前翻译：

> 你也许在想要不要加密填写在 `.password` 文件里的访问密码，不需要。该文件内的内容就是你访问该文件夹时需要的密码。

修正后翻译：

> 在上述添加的私密文件夹内创建一个 `.password` 文件，该文件内的纯文本内容就是你访问该文件夹时需要的密码。